### PR TITLE
SEARCH-1059 (Electron - Swift search - A JavaScript error displays when the user reloads the Electron while the file .lz4 is creating)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@types/ref": "0.0.28",
     "browserify": "16.2.2",
     "cross-env": "5.2.0",
-    "electron": "3.0.0-beta.7",
+    "electron": "3.0.9",
     "electron-rebuild": "1.7.3",
     "jest": "23.4.1",
     "ts-jest": "23.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "2.0.1-r53",
+  "version": "2.0.2",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/search.ts
+++ b/src/search.ts
@@ -579,10 +579,20 @@ function clearSearchData(this: Search): void {
                 if (fs.lstatSync(curPath).isDirectory()) {
                     removeFiles(curPath);
                 } else {
-                    fs.unlinkSync(curPath);
+                    try {
+                        fs.unlinkSync(curPath);
+                    } catch (e) {
+                        log.send(logLevels.WARN, 'clearSearchData -> Error removing index file ' +
+                            '(nothing to worry this will be replaced by lz4 extraction)');
+                    }
                 }
             });
-            fs.rmdirSync(filePath);
+            try {
+                fs.rmdirSync(filePath);
+            } catch (e) {
+                log.send(logLevels.WARN, 'clearSearchData -> Error removing index dir ' +
+                    '(nothing to worry this will be replaced by lz4 extraction)');
+            }
         }
     }
 


### PR DESCRIPTION
## Description
Electron - Swift search - A JavaScript error displays when the user reloads the Electron while the file .lz4 is creating
[SEARCH-1059](https://perzoinc.atlassian.net/browse/SEARCH-1059)

![atula_01_error](https://user-images.githubusercontent.com/596478/48604393-c0e36500-e99f-11e8-8798-b5f516a6fb92.png)


## Solution Approach
Add try catch and this is anyways replaced by lz4 extraction.

## Documentation
N/A

## Related PRs
N/A

## QA Checklist
- [x] Unit-Tests

Attach unit in PDF format against the above task lists for this branch
