### PR TITLE
SEARCH-1243 (Electron crashing after 54 pushed to corp on Thursday, Jan 10, 2019)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/search.ts
+++ b/src/search.ts
@@ -131,7 +131,9 @@ export default class Search extends SearchUtils implements SearchInterface {
             `${searchConfig.FOLDERS_CONSTANTS.PREFIX_NAME}_${this.userId}`);
         if (isFileExist.call(this, 'LZ4') && !reIndex) {
             decompression(`${userIndexPath}${searchConfig.TAR_LZ4_EXT}`, (status: boolean) => {
-                if (!status && !isFileExist.call(this, 'USER_INDEX_PATH')) {
+                if (!status) {
+                    log.send(logLevels.INFO, 'decompression: failed re-creating index');
+                    clearSearchData.call(this);
                     log.send(logLevels.INFO, 'Creating new index');
                     fs.mkdirSync(userIndexPath);
                 }

--- a/src/searchConfig.ts
+++ b/src/searchConfig.ts
@@ -49,7 +49,7 @@ const searchConfig = {
     DISK_NOT_FOUND: 'DISK_NOT_FOUND',
     DISK_NOT_READY: 'NOT_READY',
     FOLDERS_CONSTANTS: folderPaths,
-    INDEX_VERSION: 'v1',
+    INDEX_VERSION: 'v2',
     KEY_ENCODING: 'base64',
     KEY_LENGTH: 32,
     LIBRARY_CONSTANTS: libraryPaths,

--- a/tests/Search.test.ts
+++ b/tests/Search.test.ts
@@ -686,7 +686,7 @@ describe('Tests for Search', () => {
                 version: 1,
             };
             SearchUtilsAPI.updateUserConfig(1234567891011, data).then((res: UserConfig) => {
-                expect(res.indexVersion).toEqual('v1');
+                expect(res.indexVersion).toEqual('v2');
                 done();
             });
         });
@@ -699,7 +699,7 @@ describe('Tests for Search', () => {
             };
             SearchUtilsAPI.updateUserConfig(1234567891011, data).then((res: UserConfig) => {
                 expect(res.rotationId).toEqual(1);
-                expect(res.indexVersion).toEqual('v1');
+                expect(res.indexVersion).toEqual('v2');
                 done();
             });
         });


### PR DESCRIPTION
## Description
Electron crashing after 54 pushed to corp on Thursday, Jan 10, 2019
[SEARCH-1243](https://perzoinc.atlassian.net/browse/SEARCH-1243)

## Solution Approach
The fix is just to create a new Index.

## Documentation
N/A

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
other_pr_dev | [link]()

## QA Checklist
- [x] Unit-Tests
![screenshot 2019-01-15 at 1 20 46 pm](https://user-images.githubusercontent.com/596478/51166106-647dc280-18c8-11e9-926e-23c2b52a9eae.png)
