### PR TITLE
SEARCH-1346 - Support new field renderingBlob Swift Search

### DIFF
--- a/demo/search.html
+++ b/demo/search.html
@@ -79,6 +79,12 @@
     </div>
     <br>
     <div>
+        <label for="batchIndexing">Batch Indexing:</label><input placeholder="messages:"
+                                                                        id="batchIndexing">
+        <button id='batchMessage'>Send</button>
+    </div>
+    <br>
+    <div>
         <label for="getLatestMessageTimestamp">Get Latest Message Timestamp</label>
         <button id='getLatestMessageTimestamp'>Click</button>
     </div>
@@ -130,7 +136,9 @@
     var var1El = document.getElementById('var1');
     var table = document.getElementById('table');
     var sendMessage = document.getElementById('sendMessage');
+    var batchMessage = document.getElementById('batchMessage');
     var realTimeIndexing = document.getElementById('realTimeIndexing');
+    var batchIndexing = document.getElementById('batchIndexing');
     var timestamp = document.getElementById('getLatestMessageTimestamp');
     var has = document.getElementById('has');
     var checkFreeSpace = document.getElementById('checkFreeSpace');
@@ -212,6 +220,20 @@
             let message = realTimeIndexing.value;
             search.batchRealTimeIndexing(JSON.parse(message));
             resultsEl.innerHTML = 'success';
+        } else {
+            resultsEl.innerHTML = "Please check the entered value"
+        }
+    });
+
+    batchMessage.addEventListener('click', function () {
+        if (batchIndexing.value !== "") {
+            let message = batchIndexing.value;
+            const callback = function(res) {
+                resultsEl.innerHTML = res;
+            };
+            const msg = JSON.parse(message);
+            msg[0].renderingBlob = JSON.stringify(msg[0].renderingBlob);
+            search.indexBatch(JSON.stringify(msg), callback);
         } else {
             resultsEl.innerHTML = "Please check the entered value"
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -57,6 +57,7 @@ interface Entities {
  * Messages
  */
 export interface Message {
+    renderingBlob: string;
     messageId: string;
     text: string;
     senderId: string;

--- a/src/searchConfig.ts
+++ b/src/searchConfig.ts
@@ -49,7 +49,7 @@ const searchConfig = {
     DISK_NOT_FOUND: 'DISK_NOT_FOUND',
     DISK_NOT_READY: 'NOT_READY',
     FOLDERS_CONSTANTS: folderPaths,
-    INDEX_VERSION: 'v2',
+    INDEX_VERSION: 'v3',
     KEY_ENCODING: 'base64',
     KEY_LENGTH: 32,
     LIBRARY_CONSTANTS: libraryPaths,

--- a/tests/Search.test.ts
+++ b/tests/Search.test.ts
@@ -130,6 +130,7 @@ describe('Tests for Search', () => {
                 ingestionDate: currentDate.toString(),
                 isPublic: 'false',
                 messageId: 'Jc+4K8RtPxHJfyuDQU9atX///qN3KHYXdA==',
+                renderingBlob: '{"customEntities":[],"entityJSON":{},"presentationML":"<div data-format=\\"PresentationML\\" data-version=\\"2.0\\" class=\\"wysiwyg\\"><p>texgsd</p></div>","format":"com.symphony.messageml.v2"}',
                 senderId: '71811853189212',
                 sendingApp: 'lc',
                 text: 'it works',
@@ -235,6 +236,7 @@ describe('Tests for Search', () => {
                 '', undefined, undefined, 25, 0,
                 0).then((res: SearchResponse) => {
                 expect(res.messages.length).toEqual(3);
+                expect(res.messages[1].renderingBlob).toEqual('{"customEntities":[],"entityJSON":{},"presentationML":"<div data-format=\\"PresentationML\\" data-version=\\"2.0\\" class=\\"wysiwyg\\"><p>texgsd</p></div>","format":"com.symphony.messageml.v2"}');
                 expect(searchQuery).toHaveBeenCalled();
                 done();
             });
@@ -243,21 +245,25 @@ describe('Tests for Search', () => {
 
     describe('RealTime indexing process', () => {
 
-        it('should index realTime message', () => {
-            const message = [{
+        it('should index realTime message', (done) => {
+            const message = {
                 chatType: 'CHATROOM',
                 ingestionDate: currentDate.toString(),
                 isPublic: 'false',
                 messageId: 'Jc+4K8RtPxHJfyuDQU9atX///qN3KHYXdA==',
+                renderingBlob: '{"customEntities":[],"entityJSON":{},"presentationML":"<div data-format=\\"PresentationML\\" data-version=\\"2.0\\" class=\\"wysiwyg\\"><p>texgsd</p></div>","format":"com.symphony.messageml.v2"}',
                 senderId: '71811853189212',
                 sendingApp: 'lc',
                 text: 'realtime working',
                 threadId: 'Au8O2xKHyX1LtE6zW019GX///rZYegAtdA==',
-            }];
+            };
 
             const batchRealTimeIndexing = jest.spyOn(SearchApi, 'batchRealTimeIndexing');
             SearchApi.batchRealTimeIndexing(message);
             expect(batchRealTimeIndexing).toHaveBeenCalled();
+            setTimeout(() => {
+                done();
+            }, 1000);
         });
 
         it('should match message length', (done) => {
@@ -266,7 +272,9 @@ describe('Tests for Search', () => {
                 ['Au8O2xKHyX1LtE6zW019GX///rZYegAtdA=='],
                 '', undefined, undefined,
                 25, 0, 0).then((res: SearchResponse) => {
-                expect(res.messages.length).toEqual(3);
+                expect(res.messages.length).toEqual(4);
+                const msg = res.messages;
+                expect(msg[0].renderingBlob).toEqual('{"customEntities":[],"entityJSON":{},"presentationML":"<div data-format=\\"PresentationML\\" data-version=\\"2.0\\" class=\\"wysiwyg\\"><p>texgsd</p></div>","format":"com.symphony.messageml.v2"}');
                 expect(searchQuery).toHaveBeenCalled();
                 done();
             });
@@ -755,7 +763,7 @@ describe('Tests for Search', () => {
                 version: 1,
             };
             SearchUtilsAPI.updateUserConfig(1234567891011, data).then((res: UserConfig) => {
-                expect(res.indexVersion).toEqual('v2');
+                expect(res.indexVersion).toEqual('v3');
                 done();
             });
         });
@@ -768,7 +776,7 @@ describe('Tests for Search', () => {
             };
             SearchUtilsAPI.updateUserConfig(1234567891011, data).then((res: UserConfig) => {
                 expect(res.rotationId).toEqual(1);
-                expect(res.indexVersion).toEqual('v2');
+                expect(res.indexVersion).toEqual('v3');
                 done();
             });
         });


### PR DESCRIPTION
## Description
Support New Field for Indexing

This fixes the below bugs
[SEARCH-1346](https://perzoinc.atlassian.net/browse/SEARCH-1346)
[SEARCH-1294](https://perzoinc.atlassian.net/browse/SEARCH-1294)

### Before 
![Screenshot 2019-03-28 at 1 01 41 PM](https://user-images.githubusercontent.com/596478/55138884-7e564400-515a-11e9-8b70-adfa6c58efc7.png)

### After 
![Screenshot 2019-03-28 at 1 01 11 PM](https://user-images.githubusercontent.com/596478/55138898-84e4bb80-515a-11e9-825a-763c5c798205.png)


## Approach
[comment]: # (How does this change address the problem?)
#### Problem with the code:
- Message renderer required fields missing from the index.

#### Fix:
- Includes new library which supports indexing any fields inside `renderingBlob` so that we no longer required to change the library if any new fields are added to message object.


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
[comment]: # (List the related PRs against other branches.)

Repo | Branch | PR #
------ | ------ | ------
SFE-Client-App | branch-name | [PR #](https://github.com/SymphonyOSF/SFE-Client-App/pull/14184)
Swift-Search | branch-name | [PR #](link-to-the-PR)
SymphonyElectron | branch-name | [PR #618](https://github.com/symphonyoss/SymphonyElectron/pull/618)
SymphonyElectron | branch-name | [PR #619](https://github.com/symphonyoss/SymphonyElectron/pull/619)

## Open Questions if any and Todos
[comment]: # (When resolved, check the box and explain the answer.)
- [ ] Automation-Tests
- [x] Documentation
- [x] Language Translations
- [x] Unit-Tests