### PR TITLE
SEARCH-1496 - Clear search_index folder before decompressing

### DIFF
--- a/demo/search.html
+++ b/demo/search.html
@@ -230,6 +230,7 @@
             let message = batchIndexing.value;
             const callback = function(res) {
                 resultsEl.innerHTML = res;
+                search.encryptIndex("jjjehdnctsjyieoalskcjdhsnahsadndfnusdfsdfsd=");
             };
             const msg = JSON.parse(message);
             msg[0].renderingBlob = JSON.stringify(msg[0].renderingBlob);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/search.ts
+++ b/src/search.ts
@@ -130,6 +130,8 @@ export default class Search extends SearchUtils implements SearchInterface {
     public decompress(key: string, reIndex: boolean): void {
         const userIndexPath = path.join(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH,
             `${searchConfig.FOLDERS_CONSTANTS.PREFIX_NAME}_${this.userId}`);
+        // SEARCH-1496: Need to clear the data folder before decompression
+        clearSearchData.call(this);
         if (isFileExist.call(this, 'LZ4') && !reIndex) {
             decompression(`${userIndexPath}${searchConfig.TAR_LZ4_EXT}`, (status: boolean) => {
                 if (!status) {


### PR DESCRIPTION
## Description
App crashes when opening the Message tab after closing the app while the batch index is starting (3.x)
[SEARCH-1496](https://perzoinc.atlassian.net/browse/SEARCH-1496)

## Solution Approach
When the app is force terminated while the data is being written to disk the file gets corrupted and when we are opening that file which led to the crash. So to prevent this we clear the folder before decompression. 

## Documentation
N/A

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SymphonyElectron - `3.x` | [#645](https://github.com/symphonyoss/SymphonyElectron/pull/645)

## QA Checklist
- [x] Unit-Tests