### PR TITLE
SEARCH-1466 - Data not tracking in user custom path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/compressionLib/compression.ts
+++ b/src/compressionLib/compression.ts
@@ -7,7 +7,7 @@ import { searchConfig } from '../searchConfig';
 import { isDevEnv, isMac} from '../utils/misc';
 
 const exec = util.promisify(childProcess.exec);
-const ROOT_PATH = isDevEnv ? path.join(__dirname, '..', '..') : searchConfig.FOLDERS_CONSTANTS.USER_DATA_PATH;
+const ROOT_PATH: string = isDevEnv ? path.join(__dirname, '..', '..') : searchConfig.FOLDERS_CONSTANTS.USER_DATA_PATH;
 
 /**
  * Using the child process to execute the tar and lz4
@@ -32,7 +32,8 @@ async function compression(pathToFolder: string, outputPath: string, callback: (
         }
     } else {
         try {
-            const { stdout, stderr } = await exec(`cd "${ROOT_PATH}" && "${searchConfig.LIBRARY_CONSTANTS.WIN_LIBRARY_FOLDER}\\tar-win.exe" cf - "${pathToFolder}" | "${searchConfig.LIBRARY_CONSTANTS.LZ4_PATH}" > "${outputPath}.tar.lz4"`);
+            const drive = ROOT_PATH.substring(0, 2);
+            const { stdout, stderr } = await exec(`${drive} && cd "${ROOT_PATH}" && "${searchConfig.LIBRARY_CONSTANTS.WIN_LIBRARY_FOLDER}\\tar-win.exe" cf - "${pathToFolder}" | "${searchConfig.LIBRARY_CONSTANTS.LZ4_PATH}" > "${outputPath}.tar.lz4"`);
             if (stderr) {
                 log.send(logLevels.INFO, `compression stderr: ${stderr}`);
             }
@@ -67,7 +68,8 @@ async function decompression(pathName: string, callback: (status: boolean) => vo
         }
     } else {
         try {
-            const { stdout, stderr } = await exec(`cd "${ROOT_PATH}" && "${searchConfig.LIBRARY_CONSTANTS.LZ4_PATH}" -d "${pathName}" | "${searchConfig.LIBRARY_CONSTANTS.WIN_LIBRARY_FOLDER}\\tar-win.exe" xf - `);
+            const drive = ROOT_PATH.substring(0, 2);
+            const { stdout, stderr } = await exec(`${drive} && cd "${ROOT_PATH}" && "${searchConfig.LIBRARY_CONSTANTS.LZ4_PATH}" -d "${pathName}" | "${searchConfig.LIBRARY_CONSTANTS.WIN_LIBRARY_FOLDER}\\tar-win.exe" xf - `);
             if (stderr) {
                 log.send(logLevels.INFO, `decompression stderr: ${stderr}`);
             }


### PR DESCRIPTION
## Description
LZ4 not creating in custom user data path (was using cd on the drive)
[SEARCH-1466](https://perzoinc.atlassian.net/browse/SEARCH-1466)

## Solution Approach
Use the drive name to navigate to that drive before performing any task

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
Swift-Search - context-isolation | [#19](https://github.com/symphonyoss/SwiftSearch/pull/19)
SymphonyElectron - master | [#653](https://github.com/symphonyoss/SymphonyElectron/pull/653)
SymphonyElectron - 3.x | [#652](https://github.com/symphonyoss/SymphonyElectron/pull/652)
