### PR TITLE
SEARCH-1527 - Display swift-search version details in the More Info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "1.55.2-beta.5",
+  "version": "1.55.2-beta.6",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/search.ts
+++ b/src/search.ts
@@ -12,7 +12,6 @@ import { makeBoundTimedCollector } from './utils/queue';
 import SearchUtils from './utils/searchUtils';
 
 const exec = util.promisify(childProcess.exec);
-const SEARCH_SUPPORTED_VERSION = '1.55.3';
 
 /**
  * This search class communicates with the SymphonySearchEngine C library via node-ffi.
@@ -35,11 +34,6 @@ export default class Search extends SearchUtils implements SearchInterface {
     constructor(userId: string, key: string) {
         super();
         logger.info(`-------------------- Starting Swift-Search --------------------`);
-        const versionInfo = {
-            indexVersion: searchConfig.INDEX_VERSION,
-            supportedVersion: SEARCH_SUPPORTED_VERSION,
-        };
-        process.env.SWIFT_SEARCH = JSON.stringify(versionInfo);
         this.isInitialized = false;
         this.userId = userId;
         this.isRealTimeIndexing = false;

--- a/src/searchAPIBridge.ts
+++ b/src/searchAPIBridge.ts
@@ -32,7 +32,7 @@ export default class SSAPIBridge implements SSAPIBridgeInterface {
     }
 
     private static initSearch(data: any): void {
-        logger.info('searchAPIBridge: Swift-Search Api Bridge Created');
+        logger.info(`-------------------- Swift-Search Api Bridge Created --------------------`);
         const { userId, key } = data;
         SwiftSearchAPI = new Search(userId, key);
     }
@@ -81,6 +81,7 @@ export default class SSAPIBridge implements SSAPIBridgeInterface {
         const { method, message } = data;
 
         if (!SSAPIBridge.isLibInit() && !WHITELIST[method]) {
+            logger.info(`-------------------- searchAPIBridge: Call was made before Initializing --------------------`);
             return;
         }
 

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -12,6 +12,7 @@ export default class SearchUtils implements SearchUtilsInterface {
     public readonly indexVersion: string;
 
     constructor() {
+        logger.info(`-------------------- Swift-Search Utils Initialized --------------------`);
         this.indexVersion = searchConfig.INDEX_VERSION;
     }
 


### PR DESCRIPTION
## Description
Display swift-search version details in the More Info
[SEARCH-1527](https://perzoinc.atlassian.net/browse/SEARCH-1527)

**Preview:**
![Screenshot 2019-06-19 at 1 47 29 PM](https://user-images.githubusercontent.com/596478/59748485-d5227400-9298-11e9-85c5-c3effa0c62fb.png)



## Solution Approach
Sets the version info data in the `process.env` and displayed in the more-info window only if `Swift Search` is enabled.

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [#688](https://github.com/symphonyoss/SymphonyElectron/pull/688)
