### PR TITLE
feat: SEARCH-1562 - Check Index File Size Before Initializing Swift Search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "1.55.2-beta.7",
+  "version": "1.55.2-beta.8",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/interface/interface.ts
+++ b/src/interface/interface.ts
@@ -143,11 +143,13 @@ export interface SSAPIBridgeInterface {
     getLatestTimestamp(data: PostDataFromSFE): void;
     encryptIndex(data: PostDataFromSFE): void;
     deleteRealTimeFolder(): void;
+    publishInitializeState(arg: boolean): void;
 }
 
 export interface SearchInitialPayload {
     searchPeriod: number;
     minimumDiskSpace: number;
+    setLibInit: (state: boolean) => void;
 }
 
 export interface PostSuccessCallback {
@@ -178,6 +180,7 @@ export enum apiBridgeCmds {
     realTimeIndex = 'swift-search::real-time-index',
     deleteRealTimeIndex = 'swift-search::delete-real-time-index',
     getValidatorResponse = 'swift-search::get-validator-response',
+    setIsSwiftSearchInitialized = 'swift-search::set-is-swift-search-initialized',
 
     // Search Utils
     checkDiskSpace = 'swift-search::check-disk-space',

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -12,7 +12,6 @@ export default class SearchUtils implements SearchUtilsInterface {
     public readonly indexVersion: string;
 
     constructor() {
-        logger.info(`-------------------- Swift-Search Utils Initialized --------------------`);
         this.indexVersion = searchConfig.INDEX_VERSION;
     }
 


### PR DESCRIPTION
## Description
Check Index File Size Before Initializing Swift Search
[SEARCH-1562](https://perzoinc.atlassian.net/browse/SEARCH-1562)

## Approach
[comment]: # (How does this change address the problem?)
- **Checking disk space is done every time before Swift-Search is initialized.**
            - If low on disk space Swift-Search will be disabled
            - Else Swift-Search will continue with next process
- **Next, If the LZ4 file exists I check the size of the file**
            - If the file size exceeds, Swift-Search is disabled
            - We look at the size of LZ4 file. Let's say it is X. Then we need to check if there is (300MB - X) disk space. If so we should continue
            - Else Swift-Search will be disabled
- **Next, Validate the index**
            - Set the size of the index to the response from the validator
            - If the validation failed, initialize with fresh index
            - Else push it to ram and complete the initialization


## Learning
N/A

#### Blog Posts
N/A

## Related PRs
[comment]: # (List the related PRs against other branches.)

Repo | Branch | PR #
------ | ------ | ------
SymphonyElectron | branch-name | [PR #694](https://github.com/symphonyoss/SymphonyElectron/pull/694)
SFE-Client-App | branch-name | [PR #15317](https://github.com/SymphonyOSF/SFE-Client-App/pull/15317)


## Open Questions if any and Todos
[comment]: # (When resolved, check the box and explain the answer.)
- [ ] Automation-Tests
- [x] Documentation
- [x] Language Translations
- [x] Unit-Tests

## Custom branch on PR builder
N/A