### PR TITLE
SEARCH-1621 - Index Version in the config file gets updated immediately before lz4 file gets updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "1.55.3",
+  "version": "1.55.3-1",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/search.ts
+++ b/src/search.ts
@@ -79,17 +79,6 @@ export default class Search extends SearchUtils implements SearchInterface {
                  * index
                  */
                 this.decompress(key, true);
-
-                // Check if indexVersion exist in the config
-                // else do not update
-                const userConfig: UserConfig = config;
-                if (userConfig && userConfig.indexVersion) {
-                    userConfig.indexVersion = searchConfig.INDEX_VERSION;
-                    super.updateUserConfig(this.userId, userConfig)
-                        .catch(() => {
-                            logger.error('search: Error updating index version user config');
-                        });
-                }
             })
             .catch(() => {
                 this.decompress(key, true);


### PR DESCRIPTION
## Description
Index Version in the config file gets updated immediately before the lz4 file gets updated
[SEARCH-1621](https://perzoinc.atlassian.net/browse/SEARCH-1621)

## Solution Approach
When there is index version bump the version is updated on the config file on bootstrap which is causing to use the old index on a new library.

## Related PRs
List related PRs against other branches/repositories:

branch | PR
------ | ------
SymphonyElectron | [#747](https://github.com/symphonyoss/SymphonyElectron/pull/747)
