### PR TITLE
fix: SEARCH-1627 - FreeDiskSpace check uses FREE instead of AVAILABLE

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "1.55.3-1",
+  "version": "1.55.3-2",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/utils/checkDiskSpace.ts
+++ b/src/utils/checkDiskSpace.ts
@@ -19,16 +19,16 @@ async function checkDiskSpace(minimumDiskSpace: number): Promise<boolean> {
     }
 
     try {
-        const { free } = await DiskUsage.check(userDataPath);
+        const { available } = await DiskUsage.check(userDataPath);
 
-        logger.info(`checkDiskSpace: response from diskusage`, free);
+        logger.info(`checkDiskSpace: response from diskusage`, available);
 
-        if (!free) {
-            logger.error(`checkDiskSpace: Error retrieving available disk space`, free);
+        if (!available) {
+            logger.error(`checkDiskSpace: Error retrieving available disk space`, available);
             return false;
         }
 
-        return free >= minimumDiskSpace;
+        return available >= minimumDiskSpace;
     } catch (e) {
         logger.error(`checkDiskSpace: Error diskusage`, e);
         return false;


### PR DESCRIPTION
## Description
FreeDiskSpace check uses FREE instead of AVAILABLE
[SEARCH-1627](https://perzoinc.atlassian.net/browse/SEARCH-1627)

## Before
![Screenshot 2019-07-25 at 1 54 44 PM](https://user-images.githubusercontent.com/596478/61872020-ea299d00-aeff-11e9-9a3e-c3a8899c4844.png)

## After
![Screenshot 2019-07-25 at 5 12 26 PM](https://user-images.githubusercontent.com/596478/61872037-f4e43200-aeff-11e9-8c35-9bf104f67e76.png)
![Screenshot 2019-07-25 at 5 13 51 PM](https://user-images.githubusercontent.com/596478/61872038-f4e43200-aeff-11e9-9ad7-d260ab816478.png)


## Solution Approach
Using the free as a source will affect the disk space check. If the root system has allocated some amount of space that will be added to the free. So we need to use available in instead of free 

The calculation for available is `available = free - reserved filesystem blocks(for root)`

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SymphonyElectron | [#751](https://github.com/symphonyoss/SymphonyElectron/pull/751)

## QA Checklist
- [x] Unit-Tests