### PR TITLE
SEARCH-1646 - Include dictionary file and Update libraries for compressing the renderingBlob filed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "1.55.3-2",
+  "version": "1.55.3-3",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/search.ts
+++ b/src/search.ts
@@ -110,7 +110,7 @@ export default class Search extends SearchUtils implements SearchInterface {
             return;
         }
         libSymphonySearch.symSEDestroy();
-        libSymphonySearch.symSEInit();
+        libSymphonySearch.symSEInit(searchConfig.LIBRARY_CONSTANTS.DICTIONARY_PATH);
         libSymphonySearch.symSEClearMainRAMIndex();
         libSymphonySearch.symSEClearRealtimeRAMIndex();
         const userIndexPath = path.join(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH,
@@ -842,7 +842,7 @@ async function indexValidator(this: Search, key: string): Promise<boolean> {
         `${searchConfig.FOLDERS_CONSTANTS.PREFIX_NAME}_${this.userId}`);
     const mainIndexFolder = path.join(userIndexPath, searchConfig.FOLDERS_CONSTANTS.MAIN_INDEX);
     try {
-        const { stdout } = await exec(`"${searchConfig.LIBRARY_CONSTANTS.INDEX_VALIDATOR}" "${mainIndexFolder}" "${key}"`);
+        const { stdout } = await exec(`"${searchConfig.LIBRARY_CONSTANTS.INDEX_VALIDATOR}" "${mainIndexFolder}" "${key}" "${searchConfig.LIBRARY_CONSTANTS.DICTIONARY_PATH}"`);
         const data = JSON.parse(stdout);
         logger.info(`search: Index validator response`, { stdout: data });
         this.validatorResponse = data;

--- a/src/search.ts
+++ b/src/search.ts
@@ -110,7 +110,13 @@ export default class Search extends SearchUtils implements SearchInterface {
             return;
         }
         libSymphonySearch.symSEDestroy();
-        libSymphonySearch.symSEInit(searchConfig.LIBRARY_CONSTANTS.DICTIONARY_PATH);
+        try {
+            libSymphonySearch.symSEInit(searchConfig.LIBRARY_CONSTANTS.DICTIONARY_PATH);
+        } catch (e) {
+            logger.error(`search: Initialization failed (symSEInit)`, e);
+            this.setLibInitState(false);
+            return;
+        }
         libSymphonySearch.symSEClearMainRAMIndex();
         libSymphonySearch.symSEClearRealtimeRAMIndex();
         const userIndexPath = path.join(searchConfig.FOLDERS_CONSTANTS.INDEX_PATH,

--- a/src/searchConfig.ts
+++ b/src/searchConfig.ts
@@ -51,7 +51,7 @@ const searchConfig = {
     DISK_NOT_FOUND: 'DISK_NOT_FOUND',
     DISK_NOT_READY: 'NOT_READY',
     FOLDERS_CONSTANTS: folderPaths,
-    INDEX_VERSION: 'v4',
+    INDEX_VERSION: 'v5',
     KEY_ENCODING: 'base64',
     KEY_LENGTH: 32,
     LIBRARY_CONSTANTS: libraryPaths,

--- a/src/searchConfig.ts
+++ b/src/searchConfig.ts
@@ -18,6 +18,7 @@ const indexFolderPath = isDevEnv ? './' : userData;
 
 const winIndexValidatorArch = arch ? 'indexvalidator-x86.exe' : 'indexvalidator-x64.exe';
 const indexValidatorPath = isMac ? path.join(macLibraryPath, 'indexvalidator.exec') : path.join(winLibraryPath, winIndexValidatorArch);
+const dictionaryPath = isMac ? path.join(macLibraryPath, 'dictionary') : path.join(winLibraryPath, 'dictionary');
 
 const winSearchLibArchPath = arch ? 'libsymphonysearch-x86.dll' : 'libsymphonysearch-x64.dll';
 const libraryPath = isMac ? path.join(macLibraryPath, 'libsymphonysearch.dylib') : path.join(winLibraryPath, winSearchLibArchPath);
@@ -28,6 +29,7 @@ const userConfigFile = isDevEnv ? path.join(__dirname, '..', userConfigFileName)
 const libraryFolderPath = isMac ? macLibraryPath : winLibraryPath;
 
 const libraryPaths = {
+    DICTIONARY_PATH: dictionaryPath,
     INDEX_VALIDATOR: indexValidatorPath,
     LIBRARY_FOLDER_PATH: libraryFolderPath,
     LZ4_PATH: lz4Path,

--- a/src/searchLibrary.ts
+++ b/src/searchLibrary.ts
@@ -30,7 +30,7 @@ const lib = ffi.Library(searchConfig.LIBRARY_CONSTANTS.SEARCH_LIBRARY_PATH, {
     symSE_index_main_RAM: ['int', ['string']],
     symSE_index_realtime: ['int', ['string', 'string']],
     symSE_index_realtime_RAM: ['int', ['string']],
-    symSE_init: ['void', []],
+    symSE_init: ['void', ['string']],
     symSE_main_FS_index_to_RAM_index: ['int', ['string']],
     symSE_main_RAM_index_get_last_message_timestamp: ['char *', []],
     symSE_main_RAM_index_to_FS_index: ['int', ['string']],

--- a/tests/Search.test.ts
+++ b/tests/Search.test.ts
@@ -759,7 +759,7 @@ describe('Tests for Search', () => {
                 version: 1,
             };
             SearchUtilsAPI.updateUserConfig(1234567891011, data).then((res: UserConfig) => {
-                expect(res.indexVersion).toEqual('v4');
+                expect(res.indexVersion).toEqual('v5');
                 done();
             });
         });
@@ -772,7 +772,7 @@ describe('Tests for Search', () => {
             };
             SearchUtilsAPI.updateUserConfig(1234567891011, data).then((res: UserConfig) => {
                 expect(res.rotationId).toEqual(1);
-                expect(res.indexVersion).toEqual('v4');
+                expect(res.indexVersion).toEqual('v5');
                 done();
             });
         });

--- a/tests/SearchContextIsolation.test.ts
+++ b/tests/SearchContextIsolation.test.ts
@@ -44,7 +44,7 @@ describe('Tests for Search Context-Isolation PostMessage', () => {
     const configFile = path.join(userConfigDir, 'search_users_config.json');
 
     const UserData: any = {
-        indexVersion: 'v4',
+        indexVersion: 'v5',
         language: 'en',
         rotationId: 0,
         version: 1,


### PR DESCRIPTION
## Description
Include dictionary file and Update libraries for compressing the renderingBlob filed.
[SEARCH-1646](https://perzoinc.atlassian.net/browse/JIRA-ticket)

## Solution Approach
Due to the bot messages which users are subscribed, which contains the entire markup content used for rendering causes the index to grow very big. And to reduce the size of the index we compress the renderingBlob are using zstd lib.

Update the new libraries which compress the renderingBlob of the message object to reduce the index size.

Passing a path to the index-validator and to the library's init function so that the library can access the stored dictionary file. 

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SymphonyElectron | [#759](https://github.com/symphonyoss/SymphonyElectron/pull/759)
SymphonyElectron `master` | [#760](https://github.com/symphonyoss/SymphonyElectron/pull/760)


## QA Checklist
- [x] Unit-Tests

Attach unit in PDF format against the above task lists for this branch
