### PR TITLE
Migrate to napi version of node-ffi/ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swift-search",
-  "version": "1.55.3-5",
+  "version": "2.0.1",
   "description": "Swift Search is a Javascript binding for search library which is written in C (Apache Lucene)",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -23,11 +23,11 @@
   },
   "homepage": "https://github.com/symphonyoss/SwiftSearch#readme",
   "devDependencies": {
-    "@types/ffi": "0.2.2",
+    "@types/ffi-napi": "2.4.1",
     "@types/jest": "23.3.0",
     "@types/keymirror": "0.1.1",
     "@types/node": "10.5.2",
-    "@types/ref": "0.0.28",
+    "@types/ref-napi": "1.4.0",
     "browserify": "16.2.2",
     "cross-env": "5.2.0",
     "electron": "3.0.9",
@@ -40,8 +40,8 @@
   "dependencies": {
     "diskusage": "1.1.2",
     "electron-log": "2.2.16",
-    "ffi": "git+https://github.com/symphonyoss/node-ffi.git#v1.2.9",
+    "ffi-napi": "2.4.5",
     "keymirror": "0.1.1",
-    "ref": "1.3.5"
+    "ref-napi": "1.4.1"
   }
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,7 +1,7 @@
 import * as childProcess from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as ref from 'ref';
+import * as ref from 'ref-napi';
 import * as util from 'util';
 import { compression, decompression } from './compressionLib/compression';
 import {

--- a/src/searchLibrary.ts
+++ b/src/searchLibrary.ts
@@ -1,5 +1,5 @@
-import * as ffi from 'ffi';
-import * as ref from 'ref';
+import * as ffi from 'ffi-napi';
+import * as ref from 'ref-napi';
 
 import { searchConfig } from './searchConfig';
 


### PR DESCRIPTION
## Description
Migrate to napi version of node-ffi

## Solution Approach
Change the `ffi` module to use the napi version as there is no subsequent release for `ffi`.
This bumps both `ffi` and `ref` modules.

## Related PRs
List related PRs against other branches / repositories:

branch | PR
------ | ------
SymphonyElectron | [#767](https://github.com/symphonyoss/SymphonyElectron/pull/767)